### PR TITLE
enhance so that scopedslots can be nested

### DIFF
--- a/src/BladeComponentsScopedSlotsServiceProvider.php
+++ b/src/BladeComponentsScopedSlotsServiceProvider.php
@@ -35,11 +35,11 @@ class BladeComponentsScopedSlotsServiceProvider extends ServiceProvider
 
             $functionUses = implode(',', $functionUses);
 
-            return "<?php \$__env->slot({$name}, {$functionArguments} use ({$functionUses}) { ?>"; 
+            return "<?php \$__env->slot({$name}, {$functionArguments} use ({$functionUses}) { ob_start(); ?>"; 
         });
 
         Blade::directive('endscopedslot', function () {
-            return "<?php }); ?>";
+            return "<?php return new \Illuminate\Support\HtmlString(trim(ob_get_clean())); }); ?>";
         });
     }
 }


### PR DESCRIPTION
enable the nested usage, eg:

```
@foreach($itemGroups as $items)
    @foreach($items as $itemData)
        {{ $group($item($itemData)) }}
    @endforeach
@endforeach
```

```
@component('component', ['itemGroups' => $itemGroups])
    @scopedslot('group', ($slot)) 
        <div class="card card-body">
            {{ $slot }}
        </div>
    @endscopedslot

    @scopedslot('item', ($item))
        Item: {{ $item->id }}
    @endscopedslot
@endcomponent
```