### PR TITLE
Let @scopedslot directive be used sans parenthesis

### DIFF
--- a/src/BladeComponentsScopedSlotsServiceProvider.php
+++ b/src/BladeComponentsScopedSlotsServiceProvider.php
@@ -25,17 +25,21 @@ class BladeComponentsScopedSlotsServiceProvider extends ServiceProvider
             // Extract values from the directive's arguments array
             [$name, $functionArguments, $functionUses] = $directiveArguments;
 
+            // Wrap function arguments in parentheses if they don't already have them
+            if ($functionArguments && !preg_match('/^\(.*\)$/', $functionArguments))
+                $functionArguments = "({$functionArguments})";
+
             // Connect the arguments to form a correct function declaration
             if ($functionArguments) $functionArguments = "function {$functionArguments}";
-            
+
             $functionUses = array_filter(explode(',', trim($functionUses, '()')), 'strlen');
-            
+
             // Add `$__env` to allow usage of other Blade directives inside the scoped slot
             array_push($functionUses, '$__env');
 
             $functionUses = implode(',', $functionUses);
 
-            return "<?php \$__env->slot({$name}, {$functionArguments} use ({$functionUses}) { ?>"; 
+            return "<?php \$__env->slot({$name}, {$functionArguments} use ({$functionUses}) { ?>";
         });
 
         Blade::directive('endscopedslot', function () {


### PR DESCRIPTION
I often use the @scopedslot directive while passing only a single variable:

```
@scopedslot('name', ($user))
...
@endscopedslot
```

This PR would make the parenthesis syntax around the function arguments optional.
```
@scopedslot('name', $user)
...
@endscopedslot
```

My reasoning is as follows:
1. I would prefer not to type parenthesis every time
2. My code formatter ([vscode-blade-formatter](https://marketplace.visualstudio.com/items?itemName=shufo.vscode-blade-formatter)) will remove all parenthesis around a single variable and it causes errors.